### PR TITLE
WIP | Add local configuration to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,6 +152,8 @@ If you have two-factor authentication (2FA) enabled on your account, you need to
 1. Activate 2FA by completing the form and clicking activate.
 1. Once 2FA is enabled, use the key you copied as the value for the TOTP parameter.
 
+If you can't get 2FA working with this tool, try enabling `MAKE PRIMARY` for "Authenticator App" in your Epic account settings.
+
 ### Docker Run
 
 #### With JSON Config

--- a/Readme.md
+++ b/Readme.md
@@ -164,6 +164,21 @@ If you can't get 2FA working with this tool, try enabling `MAKE PRIMARY` for "Au
 
 `$ docker run -d -e TZ=America/Chicago -e EMAIL=example@gmail.com -e PASSWORD=abc123 -e TOTP=ABC123 -e RUN_ON_STARTUP=true -e BASE_URL=https://example.com -e SMTP_HOST=smtp.gmail.com -e SMTP_PORT=587 -e SMTP_HOST=smtp.gmail.com -e EMAIL_SENDER_ADDRESS=hello@gmail.com -e EMAIL_SENDER_NAME="Epic Games Captchas" -e EMAIL_RECIPIENT_ADDRESS=hello@gmail.com -e SMTP_SECURE=true -e SMTP_USERNAME=hello@gmail.com -e SMTP_PASSWORD=abc123 -v /my/host/dir/:/usr/app/config:rw -p 3001:3000 charlocharlie/epicgames-freegames:latest`
 
+## Local Congifuration
+
+If for some reason you don't want to use Docker to run this tool you can run it from source by cloning this repo and installing [Node.js](https://nodejs.org/).
+
+1. Get this repo from Github
+    * Clone using git (recommended): `git clone https://github.com/claabs/epicgames-freegames-node.git`
+    * Or download and unpack ZIP archive: [epicgames-freegames-node](https://github.com/claabs/epicgames-freegames-node/archive/master.zip)
+1. Create `config` folder in the cloned/unpacked directory
+1. Create [JSON configuration](#json-configuration)
+1. Install Node.js
+1. Install Node.js dependecies
+    * Start terminal and navigate to cloned/unpacked directory
+    * Run `node ci`
+1. Start application: `./node_modules/.bin/ts-node src/index.ts`
+
 ## Development
 
 ### Recommended Dev Environment Variables


### PR DESCRIPTION
I've a Windows NAS and I wanted to run this tool on it. Docker on Windows is PITA, so I figured out how run it locally.
Also, I've hit an issue with 2FA configuration not working if `Authenticator App` is not set to primary, so I added a note about this.

The local setup instructions are pretty generic, but I can expand them to be more specific (Windows/Linux) if needed.