### PR TITLE
Add Docker Buildx for multi-arch image building.

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,41 @@
+name: MultiArchDockerBuild
+
+on:
+  create:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build_multi_arch_image:
+    name: Build multi-arch Docker image.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/epicgames-freegames-node:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/epicgames-freegames-node:${{ github.sha }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/epicgames-freegames-node:latest
+            charlocharlie/epicgames-freegames:${{ github.sha }}
+            charlocharlie/epicgames-freegames:latest
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
       - name: Image digest

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,9 +1,9 @@
 name: MultiArchDockerBuild
 
 on:
-  create:
-    tags:
-      - '*'
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
@@ -34,7 +34,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/epicgames-freegames-node:${{ github.sha }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/epicgames-freegames-node:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/epicgames-freegames-node:latest
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
       - name: Image digest


### PR DESCRIPTION
This should resolve #52. I am using Docker BuildX with QEMU to cross build images for all major platforms. Node has availability on all these images, so we all amd64, arm64, arm v7, arm v6 are all supported. 

I chose to build on tags, since I see you tag releases but ultimately reference the git sha of the tagged commit to ensure immutability. 

Let me know your thoughts on this! 