### PR TITLE
Add multi-account execution script interval. Avoid multiple accounts in a short period of time, which can easily trigger the verification code.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -75,6 +75,7 @@ The config file is store in the mounted `./config` directory.
     ],
     "onlyWeekly": false,
     "runOnStartup": true,
+    "intervalTime": 60,
     "cronSchedule": "0 12 * * *",
     "runOnce": false,
     "logLevel": "info",
@@ -117,6 +118,7 @@ If you are using full JSON configuration, the only remaining Docker configurable
 | ONLY_WEEKLY             | `true`                         | `false`                 | (Optional) By default, the script will redeem all free games in the Epic Games catalog. To only redeem the weekly promotions, set to `true`        |
 | SERVER_PORT             | `3333`                         | `3000`                  | (Optional) Where the Express server listens. Useful for inter-container networks in Docker Compose, otherwise just stick to `-p`                   |
 | RUN_ON_STARTUP          | `true`                         | `false`                 | (Optional) If true, the process will run on startup in addition to the scheduled time                                                              |
+| INTERVAL_TIME           | `60`                           | `60`                    | (Optional) intervalTime controls the script execution interval of multiple accounts in seconds. (Only effective when multiple accounts are configured using config.json)                  |
 | CRON_SCHEDULE           | `0 12 * * *`                   | `0 12 * * *`            | (Optional) Cron string of when to run the process. If using `TZ=UTC`, a value of `5 16 * * *` will run 5 minutes after the new games are available |
 | RUN_ONCE                | `true`                         | `false`                 | (Optional) If true, don't schedule runs. Use with RUN_ON_STARTUP to run once and shutdown.                                                         |
 | LOG_LEVEL               | `info`                         | `info`                  | (Optional) Log level in lower case. Can be [silent, error, warn, info, debug, trace]                                                               |

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -41,6 +41,7 @@ export interface PartialConfig {
   accounts?: Partial<Account>[];
   onlyWeekly?: boolean;
   runOnStartup?: boolean;
+  intervalTime?: number;
   cronSchedule?: string;
   logLevel?: string;
   baseUrl?: string;
@@ -52,6 +53,7 @@ export interface ConfigObject extends PartialConfig {
   accounts: Account[];
   onlyWeekly: boolean;
   runOnStartup: boolean;
+  intervalTime?: number;
   cronSchedule: string;
   logLevel: string;
   baseUrl: string;
@@ -96,6 +98,7 @@ function validateConfig(config: PartialConfig): ConfigObject {
       accounts: (config.accounts as unknown) as Account[], // Native type checking doesn't work through arrays?
       onlyWeekly: config.onlyWeekly || false,
       runOnStartup: config.runOnStartup || true,
+      intervalTime: config.intervalTime || 60,
       cronSchedule: config.cronSchedule || '0 12 * * *',
       logLevel: config.logLevel || 'info',
       baseUrl: config.baseUrl || 'http://localhost:3000',
@@ -132,6 +135,7 @@ const envVarConfig: PartialConfig = {
   ],
   onlyWeekly: process.env.ONLY_WEEKLY ? Boolean(process.env.ONLY_WEEKLY) : undefined,
   runOnStartup: process.env.RUN_ON_STARTUP ? Boolean(process.env.RUN_ON_STARTUP) : undefined,
+  intervalTime: Number(process.env.INTERVAL_TIME),
   cronSchedule: process.env.CRON_SCHEDULE,
   logLevel: process.env.LOG_LEVEL,
   baseUrl: process.env.BASE_URL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,9 @@ import { newCookieJar } from './common/request';
 import './site/app';
 
 async function main(): Promise<void> {
-  const accountPromises = config.accounts.map(async account => {
-    L.info(`Checking free games for ${account.email}`);
+  const accountPromises = config.accounts.map(async (account, index) => {
+    await new Promise(resolve => setTimeout(resolve, index * (config.intervalTime || 60) * 1000));
+    L.info(`Checking free games for ${account.email} `);
     try {
       const requestClient = newCookieJar(account.email);
       const login = new Login(requestClient, account.email);


### PR DESCRIPTION
Add multi-account execution script interval. Avoid multiple accounts in a short period of time, which can easily trigger the verification code.
Added intervalTime to control the script execution interval of multiple accounts in seconds. (Only effective when multiple accounts are configured using config.json)