### PR TITLE
Add capcha URL in logs

### DIFF
--- a/src/captcha.ts
+++ b/src/captcha.ts
@@ -85,7 +85,7 @@ export async function notifyManualCaptcha(
 
     solveStep(url, email)
       .then(() => {
-        L.info({ id }, 'Action requested. Waiting for Captcha to be solved');
+        L.info({ id, url }, 'Action requested. Waiting for Captcha to be solved');
         captchaEmitter.on('solved', (captcha: CaptchaSolution) => {
           if (captcha.id === id) resolve(captcha.sessionData);
         });


### PR DESCRIPTION
Useful to have the full capcha URL in logs when you investigate an issue in logs for quick-opening.

So that instead of copy/pasting the `id` and replace in URL, you can just `ctrl+click` on URL.