### PR TITLE
Add a notifier for Gotify

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,11 @@ The config file is stored in the mounted `/usr/app/config` volume and can be nam
       "token": "a172fyyl9gw99p2xi16tq8hnib48p2",
       "userKey": "uvgidym7l5ggpwu2r8i1oy6diaapll",
     },
+    {
+      "type": "gotify",
+      "apiUrl": "https://gotify.net",
+      "token": "SnL-wAvmfo_QT",
+    },
   ],
 }
 ```

--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -31,6 +31,7 @@ export enum NotificationType {
   PUSHOVER = 'pushover',
   APPRISE = 'apprise',
   LOCAL = 'local',
+  GOTIFY = 'gotify',
 }
 
 /**
@@ -169,6 +170,40 @@ export class TelegramConfig extends NotifierConfig {
   constructor() {
     super(NotificationType.TELEGRAM);
   }
+}
+/**
+ * Sends a message to a self-hosted [Gotifier](https://gotify.net/) server
+ */
+export class GotifyConfig extends NotifierConfig {
+  /**
+   * The Gotify server host url
+   * @example http://gotify.net
+   * @env GOTIFY_API_URL
+   */
+  @IsUrl()
+  apiUrl: string;
+
+  /**
+   * The application token
+   * You need to go to Gotify WebUI and click the apps-tab in the upper right corner when logged in and add an application
+   * and then copy the Token to this field.
+   */
+  @IsNotEmpty()
+  token: string;
+
+  /**
+   * The priority of the message which defiend the sequence of message that pushes to your clinet.
+   */
+  @Max(10)
+  @Min(1)
+  priority: number;
+
+    /**
+     * @ignore
+     */
+    constructor() {
+      super(NotificationType.GOTIFY);
+    }
 }
 
 export class EmailAuthConfig {
@@ -599,6 +634,7 @@ export class AppConfig {
         { value: LocalConfig, name: NotificationType.LOCAL },
         { value: TelegramConfig, name: NotificationType.TELEGRAM },
         { value: AppriseConfig, name: NotificationType.APPRISE },
+        { value: GotifyConfig, name: NotificationType.GOTIFY }
       ],
     },
   })
@@ -609,6 +645,7 @@ export class AppConfig {
     | TelegramConfig
     | AppriseConfig
     | PushoverConfig
+    | GotifyConfig
   )[];
 
   /**

--- a/src/notifiers/gotify.ts
+++ b/src/notifiers/gotify.ts
@@ -1,52 +1,50 @@
 import got from 'got/dist/source';
 import logger from '../common/logger';
-import { NotifierService } from ".";
-import { GotifyConfig } from "../common/config/classes";
-import { NotificationReason } from "../interfaces/notification-reason";
+import { NotifierService } from './notifier-service';
+import { GotifyConfig } from '../common/config/classes';
+import { NotificationReason } from '../interfaces/notification-reason';
 
-export class GotifyNotifier extends NotifierService{
-    private config: GotifyConfig
+export class GotifyNotifier extends NotifierService {
+  private config: GotifyConfig;
 
-    constructor(config:GotifyConfig){
-        super()
-        this.config = config
+  constructor(config: GotifyConfig) {
+    super();
+    this.config = config;
+  }
+
+  async sendNotification(url: string, account: string, reason: NotificationReason): Promise<void> {
+    const L = logger.child({ user: account, reason });
+    L.trace('Sending Gotify notification');
+    const jsonPayload = {
+      title: `Epic Games free games needs a Captcha solved`,
+      /**
+       * ATTENTION: these are markdown, to make it breaking lines correctly, there is two spaces at the end of line and before the retrun
+       */
+      message: `* Reason: ${reason}  
+* Account: ${account}  
+* URL: [${url}](${url})`,
+      priority: this.config.priority,
+      extras: {
+        'client::display': {
+          contentType: 'text/markdown',
+        },
+        'client::notification': {
+          click: {
+            url,
+          },
+        },
+      },
+    };
+
+    try {
+      await got.post(`${this.config.apiUrl}/message?token=${this.config.token}`, {
+        json: jsonPayload,
+        responseType: 'json',
+      });
+    } catch (err) {
+      L.error(err);
+      L.error(this.config, `Failed to send message`);
+      throw err;
     }
-    /**
-     * @ignore
-     */
-    async sendNotification(url: string, account: string, reason: NotificationReason): Promise<void> {
-        const L=logger.child({ user: account, reason })
-        L.trace('Sending Gotify notification')
-        const jsonPayload = {
-            title: `Epic Games free games needs a Captcha solved`,
-            /**
-             * ATTENTION: these are markdown, to make it breaking lines correctly, there is two spaces at the end of line and before the retrun
-             */
-            message: `* Reason: ${reason}  
-* Account:${account}  
-* URL:[${url}](${url})`,
-            priority: this.config.priority,
-            extras: {
-                "client::display":{
-                    "contentType": "text/markdown"
-                },
-                "client::notification": {
-                    "click": { 
-                        "url": url
-                    }
-                }
-            }
-        }
-
-        try{
-            await got.post(`${this.config.apiUrl}/message?token=${this.config.token}`,{
-                json: jsonPayload,
-                responseType: "json",
-            })
-        }catch(err){
-            L.error(err);
-            L.error(this.config,`Failed to send message`);
-            throw err;
-        }
-    }
+  }
 }

--- a/src/notifiers/gotify.ts
+++ b/src/notifiers/gotify.ts
@@ -1,0 +1,53 @@
+import got from 'got/dist/source';
+import logger from '../common/logger';
+import { NotifierService } from ".";
+import { GotifyConfig } from "../common/config/classes";
+import { NotificationReason } from "../interfaces/notification-reason";
+
+export class GotifyNotifier extends NotifierService{
+    private config: GotifyConfig
+
+    constructor(config:GotifyConfig){
+        super()
+        this.config = config
+    }
+    /**
+     * @ignore
+     */
+    async sendNotification(url: string, account: string, reason: NotificationReason): Promise<void> {
+        const L=logger.child({ user: account, reason })
+        L.trace('Sending Gotify notification')
+        const jsonPayload = {
+            title: `Epic Games free games needs a Captcha solved`,
+            /**
+             * ATTENTION: these are markdown, to make it breaking lines correctly, there is two spaces at the end of line and before the retrun
+             */
+            message: `* Reason: ${reason}  
+* Account:${account}  
+* URL:[${url}](${url})`,
+            priority: this.config.priority,
+            extras: {
+                "client::display":{
+                    "contentType": "text/markdown"
+                },
+                "client::notification": {
+                    "click": { 
+                        "url": url
+                    }
+                }
+            }
+        }
+        L.info({ apiUrl:this.config.apiUrl, jsonPayload });
+
+        try{
+            await got.post(`${this.config.apiUrl}/message?token=${this.config.token}`,{
+                json: jsonPayload,
+                responseType: "json",
+            })
+        }catch(err){
+            L.error(err);
+            L.error(this.config,`Failed to send message`);
+            throw err;
+        }
+    }
+}

--- a/src/notifiers/gotify.ts
+++ b/src/notifiers/gotify.ts
@@ -37,7 +37,6 @@ export class GotifyNotifier extends NotifierService{
                 }
             }
         }
-        L.info({ apiUrl:this.config.apiUrl, jsonPayload });
 
         try{
             await got.post(`${this.config.apiUrl}/message?token=${this.config.token}`,{

--- a/src/notifiers/index.ts
+++ b/src/notifiers/index.ts
@@ -5,3 +5,4 @@ export * from './email';
 export * from './local';
 export * from './telegram';
 export * from './apprise';
+export * from './gotify'

--- a/src/notifiers/index.ts
+++ b/src/notifiers/index.ts
@@ -5,4 +5,4 @@ export * from './email';
 export * from './local';
 export * from './telegram';
 export * from './apprise';
-export * from './gotify'
+export * from './gotify';

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -4,6 +4,7 @@ import {
   EmailNotifier,
   LocalNotifier,
   TelegramNotifier,
+  GotifyNotifier,
 } from './notifiers';
 import {
   config,
@@ -14,6 +15,7 @@ import {
   TelegramConfig,
   AppriseConfig,
   PushoverConfig,
+  GotifyConfig,
 } from './common/config';
 import L from './common/logger';
 import { NotificationReason } from './interfaces/notification-reason';
@@ -53,6 +55,8 @@ export async function sendNotification(
         return new TelegramNotifier(notifierConfig as TelegramConfig);
       case NotificationType.APPRISE:
         return new AppriseNotifier(notifierConfig as AppriseConfig);
+      case NotificationType.GOTIFY:
+        return new GotifyNotifier(notifierConfig as GotifyConfig)
       default:
         throw new Error(`Unexpected notifier config: ${notifierConfig.type}`);
     }

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -56,7 +56,7 @@ export async function sendNotification(
       case NotificationType.APPRISE:
         return new AppriseNotifier(notifierConfig as AppriseConfig);
       case NotificationType.GOTIFY:
-        return new GotifyNotifier(notifierConfig as GotifyConfig)
+        return new GotifyNotifier(notifierConfig as GotifyConfig);
       default:
         throw new Error(`Unexpected notifier config: ${notifierConfig.type}`);
     }


### PR DESCRIPTION
[Gotify](https://gotify.net) is a simple self-hosted message push service which has full platform clients support and easy to integrated with.
With the new notifier, the epicgames-freegames-node could sending message to the clients via Gotify like these:
WebUI:
![image](https://user-images.githubusercontent.com/13380647/147848897-8fcaf189-1311-4489-bf7b-9257e5c580b1.png)
Android:
![a8e91ad642d08175993e4ff5d01eede](https://user-images.githubusercontent.com/13380647/147848919-e087a1f9-00cf-4f14-ac6c-40da12d63212.jpg)

Thank you for reviewing my code. 