### PR TITLE
Support for guilded.gg webhooks

### DIFF
--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -103,7 +103,6 @@ export class DiscordConfig extends NotifierConfig {
    * @env DISCORD_WEBHOOK
    */
   @IsUrl()
-  @Matches(/^.*((discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9-_]+)|guilded.gg\/webhooks\/([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_]+))$/)
   webhookUrl: string;
 
   /**

--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -103,7 +103,7 @@ export class DiscordConfig extends NotifierConfig {
    * @env DISCORD_WEBHOOK
    */
   @IsUrl()
-  @Matches(/^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$/)
+  @Matches(/^.*((discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9-_]+)|guilded.gg\/webhooks\/([a-zA-Z0-9-_]+)\/([a-zA-Z0-9-_]+))$/)
   webhookUrl: string;
 
   /**


### PR DESCRIPTION
It may be a better idea to remove the regex completely, as there are other services that use the Discord Webhook API. However, this simply adds support for guilded.gg webhooks.