### PR TITLE
Support for slack webhook

### DIFF
--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -32,6 +32,7 @@ export enum NotificationType {
   APPRISE = 'apprise',
   LOCAL = 'local',
   GOTIFY = 'gotify',
+  SLACK = 'slack',
 }
 
 /**
@@ -236,6 +237,27 @@ export class GotifyConfig extends NotifierConfig {
   }
 }
 
+/**
+ * Sends a [slack](https://slack.com/) message using webhook
+ */
+ export class SlackConfig extends NotifierConfig {
+  /**
+   * slack channel webhook URL.
+   * Guide: https://api.slack.com/messaging/webhooks
+   * @example https://hooks.slack.com/services/T22CE80ABCD/CE3AWABCDEFG/F8jdewBb4fmDDx6fV0abcdefg
+   * @env SLACK_WEBHOOK
+   */
+   @IsUrl()
+   webhookUrl: string;
+
+  /**
+   * @ignore
+   */
+  constructor() {
+    super(NotificationType.SLACK);
+  }
+}
+
 export class EmailAuthConfig {
   /**
    * The SMTP username (if necessary)
@@ -341,7 +363,8 @@ export type AnyNotifierConfig =
   | TelegramConfig
   | AppriseConfig
   | PushoverConfig
-  | GotifyConfig;
+  | GotifyConfig
+  | SlackConfig;
 
 const notifierSubtypes: {
   value: ClassConstructor<NotifierConfig>;
@@ -354,6 +377,7 @@ const notifierSubtypes: {
   { value: TelegramConfig, name: NotificationType.TELEGRAM },
   { value: AppriseConfig, name: NotificationType.APPRISE },
   { value: GotifyConfig, name: NotificationType.GOTIFY },
+  { value: SlackConfig, name: NotificationType.SLACK },
 ];
 
 export class WebPortalConfig {

--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -240,15 +240,15 @@ export class GotifyConfig extends NotifierConfig {
 /**
  * Sends a [slack](https://slack.com/) message using webhook
  */
- export class SlackConfig extends NotifierConfig {
+export class SlackConfig extends NotifierConfig {
   /**
    * slack channel webhook URL.
    * Guide: https://api.slack.com/messaging/webhooks
    * @example https://hooks.slack.com/services/T22CE80ABCD/CE3AWABCDEFG/F8jdewBb4fmDDx6fV0abcdefg
    * @env SLACK_WEBHOOK
    */
-   @IsUrl()
-   webhookUrl: string;
+  @IsUrl()
+  webhookUrl: string;
 
   /**
    * @ignore
@@ -914,6 +914,19 @@ export class AppConfig {
       }
       if (!this.notifiers.some((notifConfig) => notifConfig instanceof GotifyConfig)) {
         this.notifiers.push(gotify);
+      }
+    }
+
+    // Use environment variables to fill slack notification config if present
+    const { SLACK_WEBHOOK } = process.env;
+    if (SLACK_WEBHOOK) {
+      const slack = new SlackConfig();
+      slack.webhookUrl = SLACK_WEBHOOK;
+      if (!this.notifiers) {
+        this.notifiers = [];
+      }
+      if (!this.notifiers.some((notifConfig) => notifConfig instanceof SlackConfig)) {
+        this.notifiers.push(slack);
       }
     }
 

--- a/src/notifiers/index.ts
+++ b/src/notifiers/index.ts
@@ -6,3 +6,4 @@ export * from './local';
 export * from './telegram';
 export * from './apprise';
 export * from './gotify';
+export * from './slack';

--- a/src/notifiers/slack.ts
+++ b/src/notifiers/slack.ts
@@ -1,0 +1,35 @@
+import got from 'got';
+import logger from '../common/logger';
+import { NotifierService } from './notifier-service';
+import { NotificationReason } from '../interfaces/notification-reason';
+import { SlackConfig } from '../common/config';
+
+export class SlackNotifier extends NotifierService {
+  private config: SlackConfig;
+
+  constructor(config: SlackConfig) {
+    super();
+    this.config = config;
+  }
+
+  async sendNotification(url: string, account: string, reason: NotificationReason): Promise<void> {
+    const L = logger.child({ user: account, reason });
+    L.trace('Sending Slack notification');
+
+    try {
+      await got.post(this.config.webhookUrl, {
+        json: {
+          text: `epicgames-freegames-node needs a captcha solved. \nReason: ${reason} \nAccount: ${account} \nURL: ${url}`
+        },
+        responseType: 'text',
+      });
+    } catch (err) {
+      L.error(err);
+      L.error(
+        { SlackConfig: this.config },
+        'Error sending Slack message. Please check your configuration'
+      );
+      throw err;
+    }
+  }
+}

--- a/src/notifiers/slack.ts
+++ b/src/notifiers/slack.ts
@@ -19,7 +19,7 @@ export class SlackNotifier extends NotifierService {
     try {
       await got.post(this.config.webhookUrl, {
         json: {
-          text: `epicgames-freegames-node needs a captcha solved. \nReason: ${reason} \nAccount: ${account} \nURL: ${url}`
+          text: `epicgames-freegames-node needs a captcha solved. \nReason: ${reason} \nAccount: ${account} \nURL: ${url}`,
         },
         responseType: 'text',
       });

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -5,6 +5,7 @@ import {
   LocalNotifier,
   TelegramNotifier,
   GotifyNotifier,
+  SlackNotifier,
 } from './notifiers';
 import {
   config,
@@ -16,6 +17,7 @@ import {
   AppriseConfig,
   PushoverConfig,
   GotifyConfig,
+  SlackConfig,
 } from './common/config';
 import L from './common/logger';
 import { NotificationReason } from './interfaces/notification-reason';
@@ -57,6 +59,8 @@ export async function sendNotification(
         return new AppriseNotifier(notifierConfig as AppriseConfig);
       case NotificationType.GOTIFY:
         return new GotifyNotifier(notifierConfig as GotifyConfig);
+      case NotificationType.SLACK:
+        return new SlackNotifier(notifierConfig as SlackConfig);
       default:
         throw new Error(`Unexpected notifier config: ${notifierConfig.type}`);
     }


### PR DESCRIPTION
Hi claabs,

Thank you for this awesome project and I've been using it for a while.

Telegram and Discord are great notifier options, but since I use slack more often, it would be easier for me to manage notifications if the notifier can push to slack. 

So, I added slack webhook support for notifier option, and it seems #185 asked for it as well.
It'll send a simple text message to the channel configured in the webhook. 

Cheers, 
ypwub5