### PR TITLE
offer.productSlug can be undefined

### DIFF
--- a/src/puppet/free-games.ts
+++ b/src/puppet/free-games.ts
@@ -308,7 +308,7 @@ export default class PuppetFreeGames extends PuppetBase {
     }
 
     // HACK: fix for "Knockout City Cross-Play Beta"
-    if (offer.productSlug.endsWith('/beta')) return undefined;
+    if (offer.productSlug?.endsWith('/beta')) return undefined;
 
     return {
       offerId: offer.id,


### PR DESCRIPTION
```json
err: {
  "type": "TypeError",
  "message": "Cannot read properties of null (reading 'endsWith')",
  "stack":
  TypeError: Cannot read properties of null (reading 'endsWith')
  at PuppetFreeGames.getFreeCatalogOffer (/usr/app/src/puppet/free-games.ts:311:27)
  at runMicrotasks (<anonymous>)
  at processTicksAndRejections (node:internal/process/task_queues:96:5)
  at async Promise.all (index 5)
  at PuppetFreeGames.getWeeklyFreeGames (/usr/app/src/puppet/free-games.ts:206:7)
  at PuppetFreeGames.getAllFreeGames (/usr/app/src/puppet/free-games.ts:332:27)
  at redeemAccount (/usr/app/src/index.ts:38:20)
  at async Promise.all (index 1)
  at main (/usr/app/src/index.ts:69:5)
}
```