### PR TITLE
Add arm64 build to debian image

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -67,7 +67,7 @@ jobs:
           tags: |
             charlocharlie/epicgames-freegames:bullseye-slim
             ghcr.io/claabs/epicgames-freegames-node:bullseye-slim
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             BRANCH=${{ env.GIT_BRANCH }}


### PR DESCRIPTION
All the images have arm64 support, except the debain image.