### PR TITLE
Updated TypeScript code to handle blacklisted games based on configuration

### DIFF
--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -685,12 +685,12 @@ export class AppConfig {
   /**
    * A list of excluded game titles to skip during processing.
    * @example ['Gigabash Demo', 'Another Blacklisted Game']
-   * @env BLACKLISTED_GAMES
+   * @env BLACKLISTED_GAMES (comma separated)
    */
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  blacklistedGames?: string[];
+  blacklistedGames: string[] = [];
 
   /**
    * The search criteria for finding free games. Either the weekly promotion, and free promotion, or all free products.
@@ -1131,5 +1131,9 @@ export class AppConfig {
         port: parseInt(SERVER_PORT, 10),
       };
     }
+
+    // Use environment variables to fill blacklisted games list if present
+    const { BLACKLISTED_GAMES } = process.env;
+    if (BLACKLISTED_GAMES) this.blacklistedGames = BLACKLISTED_GAMES.split(',');
   }
 }

--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -683,6 +683,16 @@ export class AppConfig {
   cronSchedule = process.env.CRON_SCHEDULE || '0 0,6,12,18 * * *';
 
   /**
+   * A list of excluded game titles to skip during processing.
+   * @example ['Gigabash Demo', 'Another Blacklisted Game']
+   * @env BLACKLISTED_GAMES
+   */
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  blacklistedGames?: string[];
+
+  /**
    * The search criteria for finding free games. Either the weekly promotion, and free promotion, or all free products.
    * @example weekly
    * @default all

--- a/src/puppet/free-games.ts
+++ b/src/puppet/free-games.ts
@@ -353,26 +353,23 @@ export default class PuppetFreeGames extends PuppetBase {
       extensions: JSON.stringify(extensions),
     });
     const offer = offerResponseBody.data.Catalog.catalogOffer;
-    const isBlacklisted = offer.countriesBlacklist?.includes(
+    const isCountryBlacklisted = offer.countriesBlacklist?.includes(
       config.countryCode?.toUpperCase() || ''
     );
     const isFree = offer.price?.totalPrice?.discountPrice === 0;
-    this.L.trace({ offerId, namespace, isFree, isBlacklisted });
-    if (!isFree || isBlacklisted) {
+    this.L.trace({ offerId, namespace, isFree, isCountryBlacklisted });
+    if (!isFree || isCountryBlacklisted) {
       return undefined;
     }
 
-    // HACK: fix for "Knockout City Cross-Play Beta"
-    if (offer.productSlug?.endsWith('/beta')) return undefined;
-
     // Creates and checks for blacklisted games, logs and skips if found.
-    const blacklistedGames = (config.blacklistedGames ?? []).map((game: string) =>
+    const blacklistedGames = config.blacklistedGames.map((game: string) =>
       game.trim().toLowerCase()
     );
     const title = offer.title.trim().toLowerCase();
 
     if (blacklistedGames.includes(title)) {
-      console.log(`Skipping blacklisted game: ${title}`);
+      this.L.info({ title }, `Skipping blacklisted game`);
       return undefined;
     }
 

--- a/src/puppet/free-games.ts
+++ b/src/puppet/free-games.ts
@@ -365,6 +365,15 @@ export default class PuppetFreeGames extends PuppetBase {
     // HACK: fix for "Knockout City Cross-Play Beta"
     if (offer.productSlug?.endsWith('/beta')) return undefined;
 
+    // Creates and checks for blacklisted games, logs and skips if found.
+    const blacklistedGames = (config.blacklistedGames ?? []).map((game: string) => game.trim().toLowerCase());
+    const title = offer.title.trim().toLowerCase();
+
+    if (blacklistedGames.includes(title)) {
+      console.log(`Skipping blacklisted game: ${title}`);
+      return undefined;
+    }
+
     return {
       offerId: offer.id,
       offerNamespace: offer.namespace,

--- a/src/puppet/free-games.ts
+++ b/src/puppet/free-games.ts
@@ -366,7 +366,9 @@ export default class PuppetFreeGames extends PuppetBase {
     if (offer.productSlug?.endsWith('/beta')) return undefined;
 
     // Creates and checks for blacklisted games, logs and skips if found.
-    const blacklistedGames = (config.blacklistedGames ?? []).map((game: string) => game.trim().toLowerCase());
+    const blacklistedGames = (config.blacklistedGames ?? []).map((game: string) =>
+      game.trim().toLowerCase()
+    );
     const title = offer.title.trim().toLowerCase();
 
     if (blacklistedGames.includes(title)) {


### PR DESCRIPTION
Added blacklistedGames property to the config file. Added comments for clarity and better code understanding.

Update your configuration file to include a blacklistedGames array. Add the titles of games you want to exclude from processing.

"blacklistedGames": [
  "Game Title 1",
  "Game Title 2",
  "Game Title 3"
]

I included the blacklistedGames property to provide better control. "Gigabash Demo" repeatedly triggered notifications prompting a purchase. Now, with the ability to define excluded games, I can skip titles that I cant buy.