### PR TITLE
Add URL on Discord notification content

### DIFF
--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -135,11 +135,14 @@ export class DiscordConfig extends NotifierConfig {
   mentionedRoles: string[];
 
   /**
-   * Should show the URL on the message content
+   * If true, the Discord message will contain the full URL in the message text. Helpful if you need to copy-paste the URL.
+   * @example true
+   * @default false
+   * @env DISCORD_SHOW_URL
    */
   @IsBoolean()
   @IsOptional()
-  showUrl?: boolean;
+  showUrl = false;
 
   /**
    * @ignore
@@ -1031,12 +1034,14 @@ export class AppConfig {
     }
 
     // Use environment variables to fill discord notification config if present
-    const { DISCORD_WEBHOOK, DISCORD_MENTIONED_USERS, DISCORD_MENTIONED_ROLES } = process.env;
+    const { DISCORD_WEBHOOK, DISCORD_MENTIONED_USERS, DISCORD_MENTIONED_ROLES, DISCORD_SHOW_URL } =
+      process.env;
     if (DISCORD_WEBHOOK) {
       const discord = new DiscordConfig();
       discord.webhookUrl = DISCORD_WEBHOOK;
       if (DISCORD_MENTIONED_USERS) discord.mentionedUsers = DISCORD_MENTIONED_USERS.split(',');
       if (DISCORD_MENTIONED_ROLES) discord.mentionedRoles = DISCORD_MENTIONED_ROLES.split(',');
+      discord.showUrl = DISCORD_SHOW_URL === 'true';
       if (!this.notifiers) {
         this.notifiers = [];
       }

--- a/src/common/config/classes.ts
+++ b/src/common/config/classes.ts
@@ -135,6 +135,13 @@ export class DiscordConfig extends NotifierConfig {
   mentionedRoles: string[];
 
   /**
+   * Should show the URL on the message content
+   */
+  @IsBoolean()
+  @IsOptional()
+  showUrl?: boolean;
+
+  /**
    * @ignore
    */
   constructor() {

--- a/src/notifiers/discord.ts
+++ b/src/notifiers/discord.ts
@@ -28,7 +28,7 @@ export class DiscordNotifier extends NotifierService {
       await axios.post(
         this.config.webhookUrl,
         {
-          content: `${mentions}epicgames-freegames-node needs an action performed.`,
+          content: `${mentions}epicgames-freegames-node needs an action performed. ${url}`,
           embeds: [
             {
               fields: [

--- a/src/notifiers/discord.ts
+++ b/src/notifiers/discord.ts
@@ -28,7 +28,7 @@ export class DiscordNotifier extends NotifierService {
       await axios.post(
         this.config.webhookUrl,
         {
-          content: `${mentions}epicgames-freegames-node needs an action performed. ${this.config.showUrl ? url : null}`,
+          content: `${mentions}epicgames-freegames-node needs an action performed. ${this.config.showUrl && url ? `\n${url}` : ''}`,
           embeds: [
             {
               fields: [

--- a/src/notifiers/discord.ts
+++ b/src/notifiers/discord.ts
@@ -28,7 +28,7 @@ export class DiscordNotifier extends NotifierService {
       await axios.post(
         this.config.webhookUrl,
         {
-          content: `${mentions}epicgames-freegames-node needs an action performed. ${url}`,
+          content: `${mentions}epicgames-freegames-node needs an action performed. ${this.config.showUrl ? url : null}`,
           embeds: [
             {
               fields: [


### PR DESCRIPTION
Add the URL on the Discord notification content.

I have 3 accounts connected, each one on a different Firefox profile. This allows me to quickly copy/paste into the correct profile without first opening the link.