### PR TITLE
Send notifications for failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,14 @@ export async function redeemAccount(account: AccountConfig): Promise<void> {
     }
   } catch (e) {
     if (e.response) {
-      if (e.response.body) L.error(e.response.body);
-      else L.error(e.response);
+      if (e.response.body) {
+        L.error(e.response.body);
+        await sendNotification(account.email, NotificationReason.FAILURE, e.response.body);
+      }
+      else {
+        L.error(e.response);
+        await sendNotification(account.email, NotificationReason.FAILURE, e.response);
+      }
     }
     L.error(e);
     logVersionOnError();

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,7 @@ export async function redeemAccount(account: AccountConfig): Promise<void> {
       if (e.response.body) {
         L.error(e.response.body);
         await sendNotification(account.email, NotificationReason.PURCHASE_ERROR, e.response.body);
-      }
-      else {
+      } else {
         L.error(e.response);
         await sendNotification(account.email, NotificationReason.PURCHASE_ERROR, e.response);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,11 +60,11 @@ export async function redeemAccount(account: AccountConfig): Promise<void> {
     if (e.response) {
       if (e.response.body) {
         L.error(e.response.body);
-        await sendNotification(account.email, NotificationReason.FAILURE, e.response.body);
+        await sendNotification(account.email, NotificationReason.PURCHASE_ERROR, e.response.body);
       }
       else {
         L.error(e.response);
-        await sendNotification(account.email, NotificationReason.FAILURE, e.response);
+        await sendNotification(account.email, NotificationReason.PURCHASE_ERROR, e.response);
       }
     }
     L.error(e);


### PR DESCRIPTION
I don't know how to test this, but it seems like everything is mostly in place already to send a notification when it fails for some reason. Including the 401 error being experienced by lots of people recently. This just adds the notification in the catch block that otherwise prints to log. 