### PR TITLE
fix: remove protocolTimeout:0 and use domcontentloaded to prevent browser hang

### DIFF
--- a/src/common/puppeteer.ts
+++ b/src/common/puppeteer.ts
@@ -81,7 +81,6 @@ export function getDevtoolsUrl(page: Page): string {
 export const launchArgs: Parameters<typeof puppeteer.launch>[0] = {
   executablePath: executablePath(),
   headless: true,
-  protocolTimeout: 0, // https://github.com/puppeteer/puppeteer/issues/9927
   args: [
     '--disable-web-security', // For accessing iframes
     '--disable-features=IsolateOrigins,site-per-process', // For accessing iframes

--- a/src/puppet/base.ts
+++ b/src/puppet/base.ts
@@ -52,7 +52,7 @@ export default class PuppetBase {
   ): Promise<T> {
     if (!this.page) {
       this.page = await this.setupPage();
-      await this.page.goto(STORE_CART_EN, { waitUntil: 'networkidle0' });
+      await this.page.goto(STORE_CART_EN, { waitUntil: 'domcontentloaded' });
     }
 
     let fetchUrl: URL;
@@ -84,7 +84,7 @@ export default class PuppetBase {
   ): Promise<RawRequestResponse> {
     if (!this.page) {
       this.page = await this.setupPage();
-      await this.page.goto(STORE_CART_EN, { waitUntil: 'networkidle0' });
+      await this.page.goto(STORE_CART_EN, { waitUntil: 'domcontentloaded' });
     }
 
     const fetchUrl = new URL(url);
@@ -147,7 +147,7 @@ export default class PuppetBase {
     try {
       this.L.trace(getDevtoolsUrl(this.page));
       await this.browser.setCookie(...puppeteerCookies);
-      await this.page.goto(STORE_CART_EN, { waitUntil: 'networkidle0' }); // Get EG1 cookie
+      await this.page.goto(STORE_CART_EN, { waitUntil: 'domcontentloaded' }); // Get EG1 cookie
       return this.page;
     } catch (err) {
       await this.handlePageError(err);


### PR DESCRIPTION
## Problem

Two Puppeteer issues cause the browser to hang indefinitely on certain environments (observed on Synology NAS, Alpine containers, and hosted CI runners), ultimately hitting the retry limit with `Could not do browser launch after N failed attempts`.

### 1. `protocolTimeout: 0` causes an indefinite CDP hang

Setting `protocolTimeout: 0` disables all timeouts on the Chrome DevTools Protocol connection. On some hosts (constrained NAS devices, shared CI runners), the CDP handshake stalls and never completes. Because there is no timeout, the `pTimeout` wrapper never fires - the process just hangs until the outer process timeout kills it.

The linked Puppeteer issue (#9927) was reported for a very specific race condition that has since been addressed upstream. Disabling the protocol timeout entirely is a heavy-handed workaround that causes a worse failure mode than the original bug.

**Fix:** remove `protocolTimeout: 0`. The default Puppeteer protocol timeout (30 s) is appropriate and allows the existing retry logic to work correctly.

Fixes #403, #442, #361.

### 2. `waitUntil: 'networkidle0'` causes navigation timeouts on Epic's pages

`networkidle0` waits until there are zero active network connections for 500 ms. Epic's store pages fire continuous analytics/tracking requests and never reach a true idle state, causing `page.goto()` to time out.

**Fix:** use `waitUntil: 'domcontentloaded'` instead. The DOM is all that's needed before making API calls via `page.evaluate()` - waiting for network idle is unnecessary here.

## Changes

- `src/common/puppeteer.ts`: remove `protocolTimeout: 0` from `launchArgs`
- `src/puppet/base.ts`: change `waitUntil: 'networkidle0'` ? `'domcontentloaded'` in `request()`, `requestRaw()`, and `setupPage()`