### PR TITLE
fix(notifiers/homeassistant): strip trailing slash from instance URL

### DIFF
--- a/src/notifiers/homeassistant.ts
+++ b/src/notifiers/homeassistant.ts
@@ -18,8 +18,9 @@ export class HomeassistantNotifier extends NotifierService {
     L.trace('Sending homeassistant notification');
 
     try {
+      const baseUrl = this.config.instance.replace(/\/+$/, '');
       await axios.post(
-        `${this.config.instance}/api/services/notify/${this.config.notifyservice}`,
+        `${baseUrl}/api/services/notify/${this.config.notifyservice}`,
         {
           title: `Action request from Epic Games`,
           message: `epicgames needs an action performed. Reason: ${reason} {{ '\n' -}} Link: ${url}`,


### PR DESCRIPTION
### Problem

When a Home Assistant instance URL is configured with a trailing slash (e.g. `https://home.domain.com/`), the notifier builds the endpoint as `https://home.domain.com//api/services/notify/<service>`. Home Assistant rejects the double-slash path with a 404, so notifications silently fail. This is the failure mode described in #303 (still open, unassigned).

### Fix

Normalize the configured `instance` by stripping trailing slashes before concatenating the API path:

```ts
const baseUrl = this.config.instance.replace(/\/+$/, '');
await axios.post(`${baseUrl}/api/services/notify/${this.config.notifyservice}`, ...);
```

No new dependencies; behavior is unchanged for instance URLs without a trailing slash (the regex does not match).

### Verification

A standalone Node reproducer mirroring the URL construction shows:

- pre-fix: `http://homeassistant.local:8123//api/services/notify/mobile_app` (broken)
- post-fix: `http://homeassistant.local:8123/api/services/notify/mobile_app` (works)

`npx tsc --noEmit` exits clean.

Fixes #303